### PR TITLE
Enabled 'flying' to bounds of map search results, improved list modals

### DIFF
--- a/src/components/report/LocationSelect.jsx
+++ b/src/components/report/LocationSelect.jsx
@@ -21,7 +21,7 @@ const LocationSelect = props => {
     // Make sure user data up to now is collected, if not route back
     useEffect(() => {
         if (userData == null) {
-            alert("You must be logged in to make reports.")
+            // alert("You must be logged in to make reports.")
             history.push('/')
         }
     }, [])

--- a/src/components/report/ReportItemInfo.jsx
+++ b/src/components/report/ReportItemInfo.jsx
@@ -17,7 +17,7 @@ const ReportItemInfo = props => {
         firestore } = props.firebase
 
     // Image upload handling howto: https://dev.to/tallangroberg/how-to-do-image-upload-with-firebase-in-react-cpj
-    
+
     // State Vars
     const allInputs = { imgUrl: '' }
     const [imageAsFile, setImageAsFile] = useState('')
@@ -148,6 +148,7 @@ const ReportItemInfo = props => {
 
     return (
         <div>
+            <p>Stock Level (Required)</p>
             <ButtonGroup className="mr-2" aria-label="First group" toggle="true">
                 <Button onClick={handleStockLevel} value={3} variant="success">Just Restocked</Button>
                 <Button onClick={handleStockLevel} value={2} variant="secondary">Normal</Button>
@@ -158,8 +159,8 @@ const ReportItemInfo = props => {
 
             < Form onSubmit={handleSubmit}>
                 <Form.Group controlId="storeName">
-                    <Form.Label>What store are you in? (Leave blank if correct)</Form.Label>
-                    <Form.Control ref={storeRef} placeholder="" /> {/* TODO: Add Store name guess as placeholder param */}
+                    <Form.Label>What store are you in? (Required)</Form.Label>
+                    <Form.Control required ref={storeRef} placeholder="" /> {/* TODO: Add Store name guess as placeholder param */}
                 </Form.Group>
                 <Form.Group controlId="aisleNum">
                     <Form.Label>What aisle(s) (Optional)</Form.Label>
@@ -168,12 +169,20 @@ const ReportItemInfo = props => {
 
                 <Form.Group controlId="itemImgGrp">
                     <Form.Label> Take a photo of what you see! (optional) </Form.Label>
-                    <Form.Control
-                        name="itemImg"
-                        type="file"
-                        accept="image/*;capture=camera"
-                        multiple
-                        onChange={handleImageAsFile} />
+                    <div className="custom-file">
+                        <input
+                            type="file"
+                            name="itemImg"
+                            className="custom-file-input"
+                            id="inputGroupFile01"
+                            accept="image/*;capture=camera"
+                            aria-describedby="inputGroupFileAddon01"
+                            onChange={handleImageAsFile}
+                        />
+                        <label className="custom-file-label" htmlFor="inputGroupFile01">
+                            Take Photo
+                    </label>
+                    </div>
                 </Form.Group>
                 <Button variant="primary" type="submit" disabled={submitDisabled}>
                     Submit

--- a/src/components/utils/ItemTypeSelect.jsx
+++ b/src/components/utils/ItemTypeSelect.jsx
@@ -34,7 +34,7 @@ const ItemTypeSelect = props => {
     // Routing functions
     const checkLocationSet = (reportData) => {
         if (reportData.coordinates == null) {
-            alert("Location must be selected.")
+            // alert("Location must be selected.")
             history.push(routeBackwardDest)
         }
     }


### PR DESCRIPTION
* Fly to bounds of search results working, but needs to be triggered by button. Unclear how to trigger using callback
* Updated item upload form to fit design theme.
* Preventing list modal for clusters unless map is at full zoom.